### PR TITLE
test_proj_data_info pass

### DIFF
--- a/recon_test_pack/simulate_data.sh
+++ b/recon_test_pack/simulate_data.sh
@@ -37,7 +37,7 @@ atten_image=$2
 template_sino=$3
 
 echo "===  create ACFs"
-calculate_attenuation_coefficients --ACF my_acfs.hs ${atten_image} ${template_sino} > my_create_acfs.log 2>&1
+calculate_attenuation_coefficients --PMRT --ACF my_acfs.hs ${atten_image} ${template_sino} > my_create_acfs.log 2>&1
 if [ $? -ne 0 ]; then 
   echo "ERROR running calculate_attenuation_coefficients. Check my_create_acfs.log"; exit 1; 
 fi

--- a/src/buildblock/ProjDataInfoCylindrical.cxx
+++ b/src/buildblock/ProjDataInfoCylindrical.cxx
@@ -3,6 +3,8 @@
     Copyright (C) 2000 - 2009-10-18 Hammersmith Imanet Ltd
     Copyright (C) 2011, Kris Thielemans
     Copyright (C) 2013, 2018, University College London
+    Copyright (C) 2018, University of Hull
+
 
     This file is part of STIR.
 
@@ -25,6 +27,7 @@
 
   \brief Non-inline implementations of stir::ProjDataInfoCylindrical
 
+  \author Nikos Efthimiou
   \author Kris Thielemans
   \author Sanida Mustafovic
   \author PARAPET project
@@ -509,10 +512,18 @@ ProjDataInfoCylindrical::
 get_LOR(LORInAxialAndNoArcCorrSinogramCoordinates<float>& lor,
 	const Bin& bin) const
 {
-  const float s_in_mm = get_s(bin);
-  const float m_in_mm = get_m(bin);
-  const float tantheta = get_tantheta(bin);
-  const float phi = get_phi(bin);
+    Bin tmpBin = bin;
+    float phi = get_phi(tmpBin);
+    // N.E: Move within range ... if tilt is applied.
+    if (phi<0)
+        phi += _PI;
+    else if (phi>_PI)
+        phi -= _PI;
+
+    const float s_in_mm = get_s(tmpBin);
+    const float m_in_mm = get_m(tmpBin);
+    const float tantheta = get_tantheta(tmpBin);
+
   /* parametrisation of LOR is
      X= s*cphi + a*sphi, 
      Y= s*sphi - a*cphi, 

--- a/src/buildblock/ProjDataInfoCylindricalArcCorr.cxx
+++ b/src/buildblock/ProjDataInfoCylindricalArcCorr.cxx
@@ -5,6 +5,8 @@
     Copyright (C) 2000- 2007, Hammersmith Imanet Ltd
     Copyright (C) 2018, University College London
     Copyright (C) 2018, University of Leeds
+    Copyright (C) 2018, University of Hull
+
     This file is part of STIR.
 
     This file is free software; you can redistribute it and/or modify
@@ -27,6 +29,7 @@
   \brief Implementation of non-inline functions of class 
   stir::ProjDataInfoCylindricalArcCorr
 
+  \author Nikos Efthimiou
   \author Sanida Mustafovic
   \author Kris Thielemans
   \author Palak Wadhwa
@@ -139,6 +142,13 @@ get_bin(const LOR<float>& lor) const
   // map this to a view which corresponds to Pi anyway.
   //PW phi-intrinsic_tilt included to get the accurate bin.view_number.
   bin.view_num() = round((lor_coords.phi()-scanner_ptr->get_default_intrinsic_tilt()) / get_azimuthal_angle_sampling());
+  // N.E:Added the  rotation before the assertion, to support tilting.
+
+  if (bin.view_num() < get_min_view_num())
+      bin.view_num() += get_num_views();
+  else if (bin.view_num() > get_max_view_num())
+      bin.view_num() -= get_num_views();
+
   assert(bin.view_num()>=0);
   assert(bin.view_num()<=get_num_views());
   const bool swap_direction =

--- a/src/include/stir/ProjDataInfoCylindrical.inl
+++ b/src/include/stir/ProjDataInfoCylindrical.inl
@@ -4,6 +4,7 @@
     Copyright (C) 2013, University College London
     Copyright (C) 2013, Institute for Bioengineering of Catalonia
     Copyright (C) 2018, University of Leeds
+    Copyright (C) 2018, University of Hull
 
     This file is part of STIR.
 
@@ -26,6 +27,7 @@
 
   \brief Implementation of inline functions of class stir::ProjDataInfoCylindrical
 
+  \author Nikos Efthimiou
   \author Sanida Mustafovic
   \author Kris Thielemans
   \author Palak Wadhwa
@@ -69,8 +71,10 @@ initialise_ring_diff_arrays_if_not_done_yet() const
 
 //PW Added the view offset from the scanner, code may now support intrinsic tilt.
 float
+//N.E: Added proper casting.
 ProjDataInfoCylindrical::get_phi(const Bin& bin)const
-{ return bin.view_num()*azimuthal_angle_sampling + scanner_ptr->get_default_intrinsic_tilt();}
+{return static_cast<float>(bin.view_num())*azimuthal_angle_sampling + scanner_ptr->get_default_intrinsic_tilt();}
+
 
 
 float

--- a/src/test/test_proj_data_info.cxx
+++ b/src/test/test_proj_data_info.cxx
@@ -7,6 +7,7 @@
 
   \brief Test program for stir::ProjDataInfo hierarchy
 
+  \author Nikos Efthimiou
   \author Sanida Mustafovic
   \author Kris Thielemans
   \author Palak Wadhwa
@@ -18,6 +19,7 @@
     Copyright (C) 2000- 2011, Hammersmith Imanet Ltd
     Copyright (C) 2018, University College London
     Copyright (C) 2018, University of Leeds
+    Copyright (C) 2018, University of Hull
     This file is part of STIR.
 
     This file is free software; you can redistribute it and/or modify


### PR DESCRIPTION
For arc corrected: Move the phi in [0,pi) after tilt. 
For No arc corrected: Shift the view_num w.r.t. the det IDs. 
At this point I have tried only the test_proj_data_info. I am not sure if the reconstruction works and moreover if it produces resonable results.